### PR TITLE
fix: border

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -9,6 +9,7 @@ body{
   border-radius: 5px;
   background-color: #f9ffff;
   background-image: linear-gradient(45deg,rgba(255,186,238,.1) 25%,transparent 25%,transparent 50%,rgba(255,186,238,.1) 50%,rgba(255,186,238,.1) 75%,transparent 75%,transparent),linear-gradient(-45deg,rgba(255,186,238,.1) 25%,transparent 25%,transparent 50%,rgba(255,186,238,.1) 50%,rgba(255,186,238,.1) 75%,transparent 75%,transparent);
+  box-sizing: border-box;
   border: solid 2px #f48fb1;
 }
 


### PR DESCRIPTION
border のぶんだけコンテンツサイズが大きくなっており、横スクロールが発生していました。
`box-sizing: border-box;` を指定することで防げます。